### PR TITLE
add support for option 'scope'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "lts/*"

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ swagger-inline 'src/**/*.js' --base 'swaggerBase.json' # outputs built swagger.j
 - `logger`: Function called for logging.
 - `metadata`: Add additional annotations to the Swagger file, prefixed with "x-si"
 - `ignore`: globs of files to ignore (by default, `['node_modules/**/*', ...etc]`,
+- `scope`: matches the scope field defined in each api ( if not provided, all APIs' doc will be generated )
 
 ## Example:
 
@@ -74,6 +75,7 @@ schemes: ['http']
 
 /*
  * @api [get] /pets
+ * scope: public
  * description: "Returns all pets from the system that the user has access to"
  * responses:
  *   "200":
@@ -90,7 +92,7 @@ api.route('/pets', function() {
 #### 2) Run Command
 
 ```bash
-swagger-inline './*.js' --base './swaggerBase.yaml'
+swagger-inline './*.js' --base './swaggerBase.yaml' --scope public
 ```
 
 **Output:**

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# swagger-inline
+# swagger-inline [![Build Status](https://travis-ci.org/gaofei88/swagger-inline.svg?branch=master)](https://travis-ci.org/gaofei88/swagger-inline)
 
 Node module for extracting swagger endpoints from inline comments.
 

--- a/build/cli.js
+++ b/build/cli.js
@@ -1,0 +1,44 @@
+'use strict';
+
+var program = require('commander');
+var packageJson = require('../package.json');
+var Options = require('./options');
+var swaggerInline = require('./swagger-inline');
+
+function Cli(args) {
+    program.version(packageJson.version).usage('[options] <inputGlobs ...>').option('-b, --base [path]', 'A base swagger file.').option('-o, --out [path]', 'Output file path.').option('-f, --format [format]', 'Output swagger format (.json or .yaml).').option('-s, --scope [scope]', 'api scope to generate');
+
+    program.on('--help', function () {
+        ['Example:', '\tswagger-inline "./*.js" --base ./swaggerBase.json --out ./swagger.json --scope public'].forEach(function (line) {
+            return console.log(line);
+        });
+    });
+
+    program.parse(args);
+
+    if (program.args.length <= 0) {
+        program.outputHelp();
+        process.exit();
+    }
+
+    var providedOptions = {
+        base: program.base,
+        format: program.format,
+        out: program.out,
+        scope: program.scope,
+        logger: console.log
+    };
+
+    swaggerInline(program.args, providedOptions).then(function (output) {
+        var options = new Options(providedOptions);
+
+        if (!options.getOut()) {
+            console.log(output);
+        }
+    }).catch(function (err) {
+        console.log('An error occured:');
+        console.log(err);
+    });
+}
+
+module.exports = Cli;

--- a/build/extractor.js
+++ b/build/extractor.js
@@ -65,14 +65,14 @@ var Extractor = function () {
             lines.some(function (line) {
                 if (route) {
                     if (options && options.scope) {
-                        if (line.indexOf('scope') >= 0 && line.indexOf(options.scope) >= 0) {
+                        if (line.trim().indexOf('scope:') == 0 && line.indexOf(options.scope) >= 0) {
                             scopeMatched = true;
                             return false;
                         }
                     } else {
                         scopeMatched = true;
                     }
-                    if (line.indexOf('scope') >= 0) {
+                    if (line.trim().indexOf('scope:') == 0) {
                         return false;
                     }
                     return !pushLine(yamlLines, line); // end when lines stop being pushed

--- a/build/extractor.js
+++ b/build/extractor.js
@@ -1,0 +1,94 @@
+'use strict';
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var _extractComments = require('multilang-extract-comments');
+var jsYaml = require('js-yaml');
+
+function pushLine(array, line) {
+    if (line.trim()) {
+        array.push(line);
+        return true;
+    }
+    return false;
+}
+
+function buildEndpoint(route, yamlLines) {
+    var endpoint = {};
+
+    if (route) {
+        var yamlObject = jsYaml.load(yamlLines.join('\n'));
+
+        endpoint.method = route[1];
+        endpoint.route = route[2];
+        Object.assign(endpoint, yamlObject);
+    }
+    return endpoint;
+}
+
+var Extractor = function () {
+    function Extractor() {
+        _classCallCheck(this, Extractor);
+    }
+
+    _createClass(Extractor, null, [{
+        key: 'extractEndpointsFromCode',
+        value: function extractEndpointsFromCode(code, options) {
+            var _this = this;
+
+            var comments = this.extractComments(code, options);
+
+            return Object.keys(comments).map(function (commentKey) {
+                var comment = comments[commentKey];
+                return _this.extractEndpoint(comment.content, options);
+            }).filter(function (endpoint) {
+                return endpoint.method && endpoint.route;
+            });
+        }
+    }, {
+        key: 'extractComments',
+        value: function extractComments(code, options) {
+            return _extractComments(code, options);
+        }
+    }, {
+        key: 'extractEndpoint',
+        value: function extractEndpoint(comment, options) {
+            var _this2 = this;
+
+            var lines = comment.split('\n');
+            var yamlLines = [];
+            var route = null;
+            var scopeMatched = false;
+
+            lines.some(function (line) {
+                if (route) {
+                    if (options && options.scope) {
+                        if (line.indexOf('scope') >= 0 && line.indexOf(options.scope) >= 0) {
+                            scopeMatched = true;
+                            return false;
+                        }
+                    } else {
+                        scopeMatched = true;
+                    }
+                    return !pushLine(yamlLines, line); // end when lines stop being pushed
+                }
+                route = route || line.match(_this2.ROUTE_REGEX);
+                return false;
+            });
+
+            if (!scopeMatched) {
+                route = null;
+            }
+
+            return buildEndpoint(route, yamlLines);
+        }
+    }]);
+
+    return Extractor;
+}();
+
+Extractor.ROUTE_REGEX = /@api\s+\[(\w+)\]\s+(.*)$/m;
+
+module.exports = Extractor;

--- a/build/extractor.js
+++ b/build/extractor.js
@@ -72,6 +72,9 @@ var Extractor = function () {
                     } else {
                         scopeMatched = true;
                     }
+                    if (line.indexOf('scope') >= 0) {
+                        return false;
+                    }
                     return !pushLine(yamlLines, line); // end when lines stop being pushed
                 }
                 route = route || line.match(_this2.ROUTE_REGEX);

--- a/build/index.js
+++ b/build/index.js
@@ -1,0 +1,11 @@
+#! /usr/bin/env node
+'use strict';
+
+var cli = require('./cli');
+var swaggerInline = require('./swagger-inline');
+
+if (require.main === module) {
+    cli(process.argv);
+} else {
+    module.exports = swaggerInline;
+}

--- a/build/loader.js
+++ b/build/loader.js
@@ -1,0 +1,220 @@
+'use strict';
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var fs = require('fs');
+var path = require('path');
+var Promise = require('bluebird');
+var jsYaml = require('js-yaml');
+var glob = require('multi-glob').glob;
+
+var Loader = function () {
+    function Loader() {
+        _classCallCheck(this, Loader);
+    }
+
+    _createClass(Loader, null, [{
+        key: 'resolvePaths',
+        value: function resolvePaths(filepaths, options) {
+            var ignore = options ? options.getIgnore() : undefined;
+            return new Promise(function (resolve, reject) {
+                glob(filepaths, { ignore: ignore }, function (err, files) {
+                    return err === null ? resolve(files) : reject(err);
+                });
+            });
+        }
+    }, {
+        key: 'findSwagger',
+        value: function findSwagger() {
+            var directory = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : process.cwd();
+            var options = arguments[1];
+
+            return new Promise(function (resolve, reject) {
+                fs.readdir(directory, function (err, files) {
+                    if (err) {
+                        reject(err);
+                    } else {
+                        var swaggerCandidates = files.filter(function (file) {
+                            return Loader.SWAGGER_TYPES_REGEX.test(file);
+                        }).map(function (file) {
+                            return path.join(directory, file);
+                        });
+
+                        var swaggerPromises = swaggerCandidates.map(function (filepath) {
+                            return Loader.loadData(filepath, options).then(function (data) {
+                                return data.swagger ? Promise.resolve(data) : Promise.reject();
+                            });
+                        });
+
+                        Promise.any(swaggerPromises).then(function (loadedSwagger) {
+                            resolve(loadedSwagger);
+                        }).catch(function () {
+                            resolve({});
+                        });
+                    }
+                });
+            });
+        }
+    }, {
+        key: 'loadFiles',
+        value: function loadFiles(filepaths) {
+            return new Promise(function (resolve) {
+                var loadPromises = Promise.map(filepaths, function (filepath) {
+                    return Loader.loadFile(filepath).reflect();
+                }, { concurrency: Loader.MAX_CONCURRENCY });
+                resolve(loadPromises);
+            }).then(function (loadResults) {
+                return loadResults.map(function (loadResult) {
+                    return loadResult.isFulfilled() ? loadResult.value() : loadResult.reason();
+                });
+            });
+        }
+    }, {
+        key: 'loadFile',
+        value: function loadFile(filepath) {
+            return new Promise(function (resolve, reject) {
+                fs.readFile(filepath, 'utf-8', function (err, data) {
+                    if (err) {
+                        reject(err);
+                    } else {
+                        resolve(data);
+                    }
+                });
+            });
+        }
+    }, {
+        key: 'loadData',
+        value: function loadData(filepath, options) {
+            var extname = path.extname(filepath);
+            var loadFunction = Loader.LOADER_METHODS[extname];
+
+            if (!loadFunction) {
+                throw new Error('Did not recognize ' + filepath + '.');
+            }
+            var loaded = Loader.LOADER_METHODS[extname](filepath, options);
+            return loaded;
+        }
+    }, {
+        key: 'loadBase',
+        value: function loadBase() {
+            var _this = this;
+
+            var base = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : '';
+            var options = arguments[1];
+
+            return new Promise(function (resolve) {
+                fs.stat(base, function (err, stat) {
+                    if (!err && stat.isFile()) {
+                        _this.loadData(base, options).then(function (baseData) {
+                            resolve(baseData);
+                        });
+                    } else if (!err && stat.isDirectory()) {
+                        _this.findSwagger(base, options).then(function (baseData) {
+                            resolve(baseData);
+                        });
+                    } else {
+                        _this.findSwagger(process.cwd(), options).then(function (baseData) {
+                            resolve(baseData);
+                        });
+                    }
+                });
+            });
+        }
+    }, {
+        key: 'loadYAML',
+        value: function loadYAML(filepath, options) {
+            return Loader.loadFile(filepath).then(function (data) {
+                return Loader.addMetadata(jsYaml.load(data), filepath, options);
+            });
+        }
+    }, {
+        key: 'loadJSON',
+        value: function loadJSON(filepath, options) {
+            return Loader.loadFile(filepath).then(function (data) {
+                return Loader.addMetadata(JSON.parse(data), filepath, options);
+            });
+        }
+    }, {
+        key: 'addMetadata',
+        value: function addMetadata(data, filepath, options) {
+            if (options && options.getMetadata()) {
+                data['x-si-base'] = filepath;
+            }
+            return data;
+        }
+    }, {
+        key: 'addResponse',
+        value: function addResponse() {
+            var endpoints = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+
+            // If there's no response, add a default one
+            endpoints.forEach(function (endpoint) {
+                if (!endpoint.responses || !Object.keys(endpoint.responses).length) {
+                    endpoint.responses = {
+                        "200": {
+                            "description": "Successful response"
+                        }
+                    };
+                }
+            });
+            return endpoints;
+        }
+    }, {
+        key: 'expandParams',
+        value: function expandParams() {
+            var endpoints = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+
+            endpoints.forEach(function (endpoint) {
+                if (endpoint && endpoint.parameters) {
+                    endpoint.parameters.forEach(function (param, i) {
+                        if (typeof param === 'string') {
+                            endpoint.parameters[i] = Loader.expandParam(param);
+                        }
+                    });
+
+                    // Remove any params that couldn't be parsed
+                    endpoint.parameters = endpoint.parameters.filter(function (n) {
+                        return n != false;
+                    });
+                };
+            });
+            return endpoints;
+        }
+    }, {
+        key: 'expandParam',
+        value: function expandParam() {
+            var param = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : "";
+
+            var parsed = param.match(/(?:\((.*)\))?\s*([\w._-]+)(?:=([^{*]*))?([*])?\s*{(.*?)(?::(.*))?}\s*(.*)?/);;
+
+            if (!parsed || !parsed[1] || !parsed[2] || !parsed[5]) return false;
+
+            var out = {
+                'in': parsed[1],
+                'name': parsed[2],
+                'type': parsed[5].toLowerCase()
+            };
+
+            if (parsed[3]) out.default = parsed[3].trim();
+            if (parsed[4]) out.required = true;
+            if (parsed[6]) out.format = parsed[6];
+            if (parsed[7]) out.description = parsed[7];
+
+            return out;
+        }
+    }]);
+
+    return Loader;
+}();
+
+Loader.LOADER_METHODS = {
+    '.yaml': Loader.loadYAML,
+    '.yml': Loader.loadYAML,
+    '.json': Loader.loadJSON
+};
+Loader.SWAGGER_TYPES_REGEX = /\.json|\.yaml|\.yml/i;
+Loader.MAX_CONCURRENCY = 500;
+
+module.exports = Loader;

--- a/build/options.js
+++ b/build/options.js
@@ -1,0 +1,83 @@
+'use strict';
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var path = require('path');
+
+var Options = function () {
+    function Options() {
+        var _this = this;
+
+        var providedOptions = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+
+        _classCallCheck(this, Options);
+
+        this.options = Object.assign({}, providedOptions);
+
+        Object.keys(Options.DEFAULTS).forEach(function (option) {
+            _this.options[option] = _this.options[option] || Options.DEFAULTS[option];
+        });
+
+        if (this.options.base && !providedOptions.format) {
+            this.options.format = path.extname(this.options.base);
+        }
+
+        if (this.options.out) {
+            this.options.format = path.extname(this.options.out);
+        }
+    }
+
+    _createClass(Options, [{
+        key: 'isJSON',
+        value: function isJSON() {
+            return this.getFormat() === '.json' || !this.getFormat();
+        }
+    }, {
+        key: 'getFormat',
+        value: function getFormat() {
+            return this.options.format;
+        }
+    }, {
+        key: 'getBase',
+        value: function getBase() {
+            return this.options.base;
+        }
+    }, {
+        key: 'getOut',
+        value: function getOut() {
+            return this.options.out;
+        }
+    }, {
+        key: 'getScope',
+        value: function getScope() {
+            return this.options.scope;
+        }
+    }, {
+        key: 'getLogger',
+        value: function getLogger() {
+            return this.options.logger;
+        }
+    }, {
+        key: 'getIgnore',
+        value: function getIgnore() {
+            return this.options.ignore;
+        }
+    }, {
+        key: 'getMetadata',
+        value: function getMetadata() {
+            return this.options.metadata;
+        }
+    }]);
+
+    return Options;
+}();
+
+Options.DEFAULTS = {
+    format: '.json',
+    logger: function logger() {},
+    ignore: ['node_modules/**/*', 'bower_modules/**/*']
+};
+
+module.exports = Options;

--- a/build/swagger-inline.js
+++ b/build/swagger-inline.js
@@ -1,0 +1,93 @@
+'use strict';
+
+var Promise = require('bluebird');
+var fs = require('fs-extra');
+var jsYaml = require('js-yaml');
+var _ = require('lodash');
+var chalk = require('chalk');
+
+var Loader = require('./loader');
+var Extractor = require('./extractor');
+var Options = require('./options');
+
+function outputResult(object, options) {
+    return new Promise(function (resolve) {
+        var result = options.isJSON() ? JSON.stringify(object, null, 2) : jsYaml.dump(object);
+        var outPath = options.getOut();
+        if (outPath) {
+            fs.outputFile(outPath, result, function (err) {
+                if (err) {
+                    options.getLogger()('Failed to write swagger to ' + outPath);
+                }
+                resolve(result);
+            });
+        } else {
+            resolve(result);
+        }
+    });
+}
+
+function mergeEndpointsWithBase() {
+    var swaggerBase = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+    var endpoints = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : [];
+
+    return endpoints.reduce(function (prev, current) {
+        var method = current.method;
+        var route = current.route;
+        var descriptor = _.omit(current, ['method', 'route']);
+
+        if (!method || !route) {
+            return prev;
+        }
+
+        return _.set(prev, ['paths', route, method], descriptor);
+    }, swaggerBase);
+}
+
+function swaggerInline(globPatterns, providedOptions) {
+    if (typeof globPatterns === 'undefined') {
+        throw Error('No files specificied');
+    }
+
+    var options = new Options(providedOptions);
+    var log = options.getOut() ? options.getLogger() : function () {};
+
+    return Loader.resolvePaths(globPatterns, options).then(function (files) {
+        var base = options.getBase();
+        return Loader.loadBase(base, options).then(function (baseObj) {
+            if (Object.keys(baseObj).length === 0) {
+                log(chalk.yellow('No base swagger provided/found!'));
+            }
+
+            log(files.length + ' files matched...');
+            return Loader.loadFiles(files).then(function (filesData) {
+                var successfulFiles = filesData.map(function (fileData, index) {
+                    return { fileData: fileData, fileName: files[index] };
+                }).filter(function (fileInfo) {
+                    return typeof fileInfo.fileData === 'string';
+                });
+                var endpoints = _.flatten(successfulFiles.map(function (fileInfo) {
+                    try {
+                        var _endpoints = Extractor.extractEndpointsFromCode(fileInfo.fileData, { filename: fileInfo.fileName, scope: options.getScope() });
+
+                        _endpoints = Loader.addResponse(_endpoints);
+                        _endpoints = Loader.expandParams(_endpoints);
+                        return _endpoints;
+                    } catch (e) {
+                        log(chalk.red('Error parsing ' + fileInfo.fileName));
+                        log(chalk.red(e.toString()));
+                        return {};
+                    }
+                }));
+
+                log(endpoints.length + ' swagger definitions found...');
+
+                var swagger = mergeEndpointsWithBase(baseObj, endpoints);
+                log('swagger' + options.getFormat() + ' created!');
+                return outputResult(swagger, options);
+            });
+        });
+    });
+}
+
+module.exports = swaggerInline;

--- a/src/cli.js
+++ b/src/cli.js
@@ -9,12 +9,13 @@ function Cli(args) {
         .usage('[options] <inputGlobs ...>')
         .option('-b, --base [path]', 'A base swagger file.')
         .option('-o, --out [path]', 'Output file path.')
-        .option('-f, --format [format]', 'Output swagger format (.json or .yaml).');
+        .option('-f, --format [format]', 'Output swagger format (.json or .yaml).')
+        .option('-s, --scope [scope]', 'api scope to generate');
 
     program.on('--help', () => {
         [
             'Example:',
-            '\tswagger-inline "./*.js" --base ./swaggerBase.json --out ./swagger.json',
+            '\tswagger-inline "./*.js" --base ./swaggerBase.json --out ./swagger.json --scope public',
         ].forEach((line) => console.log(line));
     });
 
@@ -29,6 +30,7 @@ function Cli(args) {
         base: program.base,
         format: program.format,
         out: program.out,
+        scope: program.scope,
         logger: console.log,
     };
 

--- a/src/extractor.js
+++ b/src/extractor.js
@@ -54,6 +54,9 @@ class Extractor {
                 }else{
                     scopeMatched = true;
                 }
+                if(line.indexOf('scope') >= 0) {
+                    return false;
+                }
                 return !pushLine(yamlLines, line); // end when lines stop being pushed
             }
             route = route || line.match(this.ROUTE_REGEX);

--- a/src/extractor.js
+++ b/src/extractor.js
@@ -47,14 +47,14 @@ class Extractor {
         lines.some((line) => {
             if (route) {
                 if(options && options.scope){
-                    if(line.indexOf('scope') >= 0 && line.indexOf(options.scope) >= 0){
+                    if(line.trim().indexOf('scope:') == 0 && line.indexOf(options.scope) >= 0){
                         scopeMatched = true;
                         return false;
                     }
                 }else{
                     scopeMatched = true;
                 }
-                if(line.indexOf('scope') >= 0) {
+                if(line.trim().indexOf('scope:') == 0) {
                     return false;
                 }
                 return !pushLine(yamlLines, line); // end when lines stop being pushed

--- a/src/extractor.js
+++ b/src/extractor.js
@@ -28,7 +28,7 @@ class Extractor {
 
         return Object.keys(comments).map((commentKey) => {
             const comment = comments[commentKey];
-            return this.extractEndpoint(comment.content);
+            return this.extractEndpoint(comment.content, options);
         }).filter((endpoint) => {
             return endpoint.method && endpoint.route;
         });
@@ -38,18 +38,31 @@ class Extractor {
         return extractComments(code, options);
     }
 
-    static extractEndpoint(comment) {
+    static extractEndpoint(comment, options) {
         const lines = comment.split('\n');
         const yamlLines = [];
         let route = null;
+        let scopeMatched = false;
 
         lines.some((line) => {
             if (route) {
+                if(options && options.scope){
+                    if(line.indexOf('scope') >= 0 && line.indexOf(options.scope) >= 0){
+                        scopeMatched = true;
+                        return false;
+                    }
+                }else{
+                    scopeMatched = true;
+                }
                 return !pushLine(yamlLines, line); // end when lines stop being pushed
             }
             route = route || line.match(this.ROUTE_REGEX);
             return false;
         });
+
+        if (!scopeMatched){
+            route = null;
+        }
 
         return buildEndpoint(route, yamlLines);
     }

--- a/src/options.js
+++ b/src/options.js
@@ -33,6 +33,10 @@ class Options {
         return this.options.out;
     }
 
+    getScope() {
+        return this.options.scope;
+    }
+    
     getLogger() {
         return this.options.logger;
     }

--- a/src/swagger-inline.js
+++ b/src/swagger-inline.js
@@ -66,7 +66,7 @@ function swaggerInline(globPatterns, providedOptions) {
                     try {
                         let endpoints = Extractor.extractEndpointsFromCode(
                             fileInfo.fileData,
-                            { filename: fileInfo.fileName }
+                            { filename: fileInfo.fileName, scope: options.getScope() }
                         );
 
                         endpoints = Loader.addResponse(endpoints);


### PR DESCRIPTION
when publish swagger api doc, some of the APIs are meant to consumed internally only. Thus adding a 'scope' field, so that when running with '--scope public' will generate a public-only api docs.