### PR TITLE
Added scope | To fix the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ api.route('/pets', function() {
 #### 2) Run Command
 
 ```bash
-swagger-inline './*.js' --base './swaggerBase.yaml'
+swagger-inline './*.js' --base './swaggerBase.yaml' --scope public
 ```
 
 **Output:**


### PR DESCRIPTION
If `scope` is not specified the endpoint `GET /pets` is returned with the default description