### PR TITLE
add posibility to write schemes inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,24 @@ schemes: ['http']
 api.route('/pets', function() {
     /* Pet code 😺 */
 });
+
+/*
+* @schema Pet',
+* required:',
+*   - id',
+*   - name',
+* properties:',
+*   id:',
+*     type: integer'
+*     format: int64'
+*   name:',
+*     type: string',
+*   tag:',
+*     type: string',
+*/
+
+//some scheme related function
+
 ```
 
 #### 2) Run Command
@@ -119,4 +137,18 @@ paths:
           description: A list of pets.
           schema:
             type: String
+components:
+  schemes:
+    Pet:
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: intege
+          format: int6
+        name:
+          type: string
+        tag:
+          type: string
 ```

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ components:
         - name
       properties:
         id:
-          type: intege
+          type: integer
           format: int6
         name:
           type: string

--- a/src/extractor.js
+++ b/src/extractor.js
@@ -25,6 +25,18 @@ function buildEndpoint(route, yamlLines) {
     return endpoint;
 }
 
+function buildSchema(schema, yamlLines) {
+    const scheme = {};
+
+    if (schema) {
+        const yamlObject = jsYaml.load(yamlLines.join('\n'));
+
+        scheme.name = schema[1];
+        Object.assign(scheme, yamlObject);
+    }
+    return scheme;
+}
+
 class Extractor {
     static extractEndpointsFromCode(code, options) {
         const comments = this.extractComments(code, options);
@@ -34,6 +46,15 @@ class Extractor {
             return this.extractEndpoint(comment.content, options);
         }).filter((endpoint) => {
             return endpoint.method && endpoint.route;
+        });
+    }
+
+    static extractSchemasFromCode(code, options) {
+        const comments = this.extractComments(code, options);
+        
+        return Object.keys(comments).map((commentKey) => {
+            const comment = comments[commentKey];
+            return this.extractSchemas(comment.content, options);
         });
     }
 
@@ -73,8 +94,42 @@ class Extractor {
 
         return buildEndpoint(route, yamlLines);
     }
+
+    static extractSchemas(comment, options) {
+        const lines = comment.split('\n');
+        const yamlLines = [];
+        let route = null;
+        let scopeMatched = false;
+
+        lines.some((line) => {
+            if (route) {
+                if (options && options.scope) {
+                    if (line.trim().indexOf('scope:') == 0 && line.indexOf(options.scope) >= 0) {
+                        scopeMatched = true;
+                        return false;
+                    }
+                } else {
+                    scopeMatched = true;
+                }
+                if (line.trim().indexOf('scope:') == 0) {
+                    return false;
+                }
+                pushLine(yamlLines, line);
+                return;
+            }
+            route = route || line.match(this.SCHEMA_REGEX);
+            return false;
+        });
+
+        if (!scopeMatched) {
+            route = null;
+        }
+
+        return buildSchema(route, yamlLines);
+    }
 }
 
 Extractor.ROUTE_REGEX = /@(?:oas|api)\s+\[(\w+)\]\s+(.*?)(?:\s+(.*))?$/m;
+Extractor.SCHEMA_REGEX = /@schema\s+(.*)$/m;
 
 module.exports = Extractor;

--- a/tests/extractor-test.js
+++ b/tests/extractor-test.js
@@ -85,6 +85,33 @@ describe('Extractor', () => {
             });
         });
 
+        const swaggerSchemeComment = [
+            '',
+            ' @schema Pet',
+            '   required:',
+            '     - id',
+            '     - name',
+            '   properties:',
+            '     id:',
+            '       type: integer',
+            '       format: int64',
+            '     name:',
+            '       type: string',
+            '     tag:',
+            '       type: string',
+            '',
+        ].join('\n');
+
+        it('extracts schemes from comment strings', () => {
+            const scheme = Extractor.extractSchemas(swaggerSchemeComment);
+
+            assert.equal(scheme.name, 'Pet');
+            assert.isArray(scheme.required);
+            assert.isObject(scheme.properties);
+            assert.isObject(scheme.properties.id);
+        });
+
+
         it('returns only endpoints', () => {
             const emptyCode = [
                 '/*', ' * Empty comment', ' */',

--- a/tests/swagger-inline-test.js
+++ b/tests/swagger-inline-test.js
@@ -63,6 +63,18 @@ describe('Swagger Inline', () => {
             done();
         }).catch(done);
     });
+    
+    it('merges extracted schemes into the base swagger', (done) => {
+        swaggerInline(`${projectDir}/*.js`, { base: baseJSONPath }).then((json) => {
+            const outputJSON = JSON.parse(json);
+
+            Object.keys(outputJSON.components.schemas).forEach((component) => {
+                assert.isObject(outputJSON.components.schemas[component]);
+            });
+
+            done();
+        }).catch(done);
+    });
 
     it('outputs a specified json file', () => {
         const out = './tmp/swagger.json';


### PR DESCRIPTION
With this changes it is possible to actually write schema-definitions inline too (#5 )

I am sure that some stuff could be written better (for example to extracting comments only once per file), but for now this is a good/working startingpoint.
I am also aware of the possible problem of double declaration of schemas, but in my opinion, this is not a problem of swagger-inline. Maybe one could print a warning in the future.