### PR TITLE
Add new option to ignore errors

### DIFF
--- a/build/extractor.js
+++ b/build/extractor.js
@@ -90,7 +90,15 @@ var Extractor = /*#__PURE__*/function () {
   }, {
     key: "extractComments",
     value: function extractComments(code, options) {
-      return _extractComments(code, options);
+      try {
+        return _extractComments(code, options);
+      } catch (e) {
+        if (options.ignoreErrors) {
+          return {};
+        }
+
+        throw e;
+      }
     }
   }, {
     key: "extractEndpoint",

--- a/build/options.js
+++ b/build/options.js
@@ -62,6 +62,11 @@ var Options = /*#__PURE__*/function () {
     value: function getMetadata() {
       return this.options.metadata;
     }
+  }, {
+    key: "getIgnoreErrors",
+    value: function getIgnoreErrors() {
+      return this.options.ignoreErrors;
+    }
   }]);
 
   return Options;
@@ -70,6 +75,7 @@ var Options = /*#__PURE__*/function () {
 Options.DEFAULTS = {
   format: '.json',
   logger: function logger() {},
-  ignore: ['node_modules/**/*', 'bower_modules/**/*']
+  ignore: ['node_modules/**/*', 'bower_modules/**/*'],
+  ignoreErrors: false
 };
 module.exports = Options;

--- a/build/swagger-inline.js
+++ b/build/swagger-inline.js
@@ -89,14 +89,16 @@ function swaggerInline(globPatterns, providedOptions) {
           try {
             var newEndpoints = Extractor.extractEndpointsFromCode(fileInfo.fileData, {
               filename: fileInfo.fileName,
-              scope: options.getScope()
+              scope: options.getScope(),
+              ignoreErrors: options.getIgnoreErrors()
             });
             newEndpoints = Loader.addResponse(newEndpoints);
             newEndpoints = Loader.expandParams(newEndpoints, swaggerVersion);
             endpoints = _.concat(endpoints, newEndpoints);
             var scheme = Extractor.extractSchemasFromCode(fileInfo.fileData, {
               filename: fileInfo.fileName,
-              scope: options.getScope()
+              scope: options.getScope(),
+              ignoreErrors: options.getIgnoreErrors()
             });
 
             _.remove(scheme, function (s) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-inline",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5463,6 +5463,31 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^6.2.0"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        }
       }
     },
     "co": {
@@ -13046,6 +13071,29 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
         }
       }
     },
@@ -13125,6 +13173,12 @@
         "yargs-parser": "^18.1.1"
       },
       "dependencies": {
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
         "find-up": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -13135,11 +13189,28 @@
             "path-exists": "^4.0.0"
           }
         },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
         "path-exists": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
           "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
           "dev": true
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
         }
       }
     },

--- a/src/extractor.js
+++ b/src/extractor.js
@@ -73,7 +73,7 @@ class Extractor {
     try {
       return extractComments(code, options);
     } catch (e) {
-      if(options.ignoreErrors) {
+      if (options.ignoreErrors) {
         return {};
       }
       throw e;

--- a/src/extractor.js
+++ b/src/extractor.js
@@ -70,7 +70,14 @@ class Extractor {
   }
 
   static extractComments(code, options) {
-    return extractComments(code, options);
+    try {
+      return extractComments(code, options);
+    } catch (e) {
+      if(options.ignoreErrors) {
+        return {};
+      }
+      throw e;
+    }
   }
 
   static extractEndpoint(comment, options) {

--- a/src/options.js
+++ b/src/options.js
@@ -41,12 +41,17 @@ class Options {
   getMetadata() {
     return this.options.metadata;
   }
+
+  getIgnoreErrors() {
+    return this.options.ignoreErrors;
+  }
 }
 
 Options.DEFAULTS = {
   format: '.json',
   logger: () => {},
   ignore: ['node_modules/**/*', 'bower_modules/**/*'],
+  ignoreErrors: false,
 };
 
 module.exports = Options;

--- a/src/swagger-inline.js
+++ b/src/swagger-inline.js
@@ -80,6 +80,7 @@ function swaggerInline(globPatterns, providedOptions) {
               let newEndpoints = Extractor.extractEndpointsFromCode(fileInfo.fileData, {
                 filename: fileInfo.fileName,
                 scope: options.getScope(),
+                ignoreErrors: options.getIgnoreErrors(),
               });
 
               newEndpoints = Loader.addResponse(newEndpoints);
@@ -90,6 +91,7 @@ function swaggerInline(globPatterns, providedOptions) {
               const scheme = Extractor.extractSchemasFromCode(fileInfo.fileData, {
                 filename: fileInfo.fileName,
                 scope: options.getScope(),
+                ignoreErrors: options.getIgnoreErrors(),
               });
               _.remove(scheme, s => {
                 return _.isEmpty(s);


### PR DESCRIPTION
Added a new option to ignore errors when trying to parse files for comments. This allows us to be more flexible in the GitHub Action, since previously if it came across a jpg (or any file with a type it didn't know about), it would exit. This prevented us from generically running swagger-inline via a Github action.