### PR TITLE
fix: Write errors to stderr

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -35,8 +35,8 @@ function Cli(args) {
       console.log(output);
     })
     .catch(err => {
-      console.log('An error occured:');
-      console.log(err);
+      console.error('An error occured:');
+      console.error(err);
       process.exit(-1);
     });
 }


### PR DESCRIPTION
This allows you to redirect stderr and stdout separately.

This should not change the behavior of the usage example, so I did not update the README file.

Here's an example on how to write error messages to the console, and the swagger output to a file:

```bash
swagger-inline "./*.js" --base 'swaggerBase.json' 2>&1 > api.json
```
