### PR TITLE
bump multilang-extract-comments to support kotlin and scala

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-inline",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4319,9 +4319,9 @@
       "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
     },
     "comment-patterns": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/comment-patterns/-/comment-patterns-0.11.0.tgz",
-      "integrity": "sha512-YgQOR0QcCIE0mYFywZ0ToK8r7V+48FjEWA6Jflfvxf5JlGZtJEi8BzMcc4BXcaVUyU1DUSGEhppSUfJOI2YC/w==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/comment-patterns/-/comment-patterns-0.12.0.tgz",
+      "integrity": "sha512-LhP+aYhloN+w6fh+U/Vwb+zjRvz7igV6V9YDPtSkdIctaUWb2NDasssTu1ujU8Z6/X5oKE3vWjRCKjCPii2FCg==",
       "requires": {
         "lodash": "^4.17.11"
       }
@@ -9929,11 +9929,11 @@
       "dev": true
     },
     "multilang-extract-comments": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/multilang-extract-comments/-/multilang-extract-comments-0.3.3.tgz",
-      "integrity": "sha512-9NqT+Cf1yvM/eYp+ILUczzz2ca4upYbdQQwSn550ldFA7hX2WVZzo7jaddFkSfq6EkIkPaeWBL+LP+BZuHK0oA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/multilang-extract-comments/-/multilang-extract-comments-0.4.0.tgz",
+      "integrity": "sha512-8mXCo9Q42Wyfho9nn7hHkG/0sKxH0nJWfmBLl8+c+FLv++XhFkFC1sntOk4NFZ+nSpoMjlF/8ILeOLyMRTFbIw==",
       "requires": {
-        "comment-patterns": "^0.11.0",
+        "comment-patterns": "^0.12.0",
         "line-counter": "^1.0.3",
         "lodash": "^4.17.11",
         "quotemeta": "0.0.0"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "globby": "^11.0.1",
     "js-yaml": "^3.13.1",
     "lodash": "^4.17.11",
-    "multilang-extract-comments": "^0.3.2"
+    "multilang-extract-comments": "^0.4.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.7.5",


### PR DESCRIPTION
mulitlang-extract-comments version 0.4.0 has support for kotlin and scala, thus bumping it here