### PR TITLE
fix: improved error handling

### DIFF
--- a/__tests__/__fixtures__/project-openapi/README.md
+++ b/__tests__/__fixtures__/project-openapi/README.md
@@ -1,0 +1,3 @@
+This is a test README.
+
+It should not be picked up by `swagger-inline` and throw errors because it doesn't have any docblocks.

--- a/__tests__/__fixtures__/project/README.md
+++ b/__tests__/__fixtures__/project/README.md
@@ -1,0 +1,3 @@
+This is a test README.
+
+It should not be picked up by `swagger-inline` and throw errors because it doesn't have any docblocks.

--- a/__tests__/cli.test.js
+++ b/__tests__/cli.test.js
@@ -36,6 +36,22 @@ describe('CLI', () => {
     const cmd = `node bin/swagger-inline __tests__/__fixtures__/code/swagger-api.js --base __tests__/__fixtures__/project/swaggerBase.json`;
     return runCommand(cmd, workDir).then(result => {
       expect(result.code).toBe(0);
+
+      const stdout = JSON.parse(result.stdout);
+      expect(stdout.swagger).toBe('2.0');
+      expect(Object.keys(stdout.paths)).toHaveLength(2);
+    });
+  });
+
+  it("shouldn't throw errors on directories that have markdown", () => {
+    const workDir = path.resolve(__dirname, '../');
+    const cmd = `node bin/swagger-inline __tests__/__fixtures__/project-openapi --base __tests__/__fixtures__/project-openapi/openapiBase.json`;
+    return runCommand(cmd, workDir).then(result => {
+      expect(result.code).toBe(0);
+
+      const stdout = JSON.parse(result.stdout);
+      expect(stdout.openapi).toBe('3.0.3');
+      expect(Object.keys(stdout.paths)).toHaveLength(2);
     });
   });
 });

--- a/__tests__/index.test.js
+++ b/__tests__/index.test.js
@@ -1,6 +1,3 @@
-const fs = require('fs');
-const jsYaml = require('js-yaml');
-
 const swaggerInline = require('../src');
 
 describe('Swagger Inline', () => {
@@ -35,20 +32,14 @@ describe('Swagger Inline', () => {
     ['OpenAPI', `${__dirname}/__fixtures__/project-openapi`, 'openapiBase'],
     ['Swagger', `${__dirname}/__fixtures__/project`, 'swaggerBase'],
   ])('%s', (c, projectDir, base) => {
-    const baseYAMLPath = `${projectDir}/${base}.yaml`;
-    const baseJSONPath = `${projectDir}/${base}.json`;
-
     it('supports JSON', () => {
-      return swaggerInline(`${projectDir}/*.js`, { base: baseJSONPath }).then(json => {
+      return swaggerInline(`${projectDir}/*`, { base: `${projectDir}/${base}.json` }).then(json => {
         expect(JSON.parse(json)).toMatchSnapshot();
       });
     });
 
     it('supports YAML', () => {
-      const baseYAML = jsYaml.load(fs.readFileSync(baseYAMLPath, 'utf-8'));
-      expect(Object.keys(baseYAML).length).toBeGreaterThan(0);
-
-      return swaggerInline(`${projectDir}/*.js`, { base: baseYAMLPath }).then(yaml => {
+      return swaggerInline(`${projectDir}/*`, { base: `${projectDir}/${base}.yaml` }).then(yaml => {
         expect(yaml).toMatchSnapshot();
 
         expect(() => {


### PR DESCRIPTION
Adds improved error handling for when files that don't have docblocks in them, namely `.md`, `.json`, and `.txt` files.