### PR TITLE
allow the support for body content type

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -143,10 +143,10 @@ class Loader {
           } else {
             schema = base.schema;
           }
-          
-          let bodyContentType = 'application/json'
+
+          let bodyContentType = 'application/json';
           if (base.bodyContentType) {
-            bodyContentType = base.bodyContentType
+            bodyContentType = base.bodyContentType;
           }
 
           endpoint.requestBody = {

--- a/src/loader.js
+++ b/src/loader.js
@@ -143,10 +143,15 @@ class Loader {
           } else {
             schema = base.schema;
           }
+          
+          let bodyContentType = 'application/json'
+          if (base.bodyContentType) {
+            bodyContentType = base.bodyContentType
+          }
 
           endpoint.requestBody = {
             content: {
-              'application/json': {
+              [bodyContentType]: {
                 schema,
               },
             },


### PR DESCRIPTION
currently is not possible to support a body content type different by `application/json`, with this implementation, the user will be able to pass a custom content type like `multipart/form-data`