### PR TITLE
feat: ensuring that exported definitions are sorted by path and method

### DIFF
--- a/__tests__/__fixtures__/project-openapi/api.js
+++ b/__tests__/__fixtures__/project-openapi/api.js
@@ -1,4 +1,36 @@
 /*
+ * @api [post] /pets
+ *    description: "Creates a new pet in the store. Duplicates are allowed"
+ *    operationId: "addPet"
+ *    requestBody:
+ *      description: "Pet to add to the store"
+ *      required: true
+ *      content:
+ *        application/json:
+ *          schema:
+ *            $ref: "#/components/schemas/Pet"
+ *    responses:
+ *      "200":
+ *        description: "pet response"
+ *        content:
+ *          application/json:
+ *            schema:
+ *              type: "array"
+ *              items:
+ *                $ref: "#/components/schemas/Pet"
+ *      default:
+ *        description: "unexpected error"
+ *        content:
+ *          application/json:
+ *            schema:
+ *              $ref: "#/components/schemas/ErrorModel"
+ */
+
+router.post('/pets', () => {
+
+});
+
+/*
  * @api [get] /pets
  *    description: "Returns all pets from the system that the user has access to"
  *    operationId: "findPets"
@@ -39,38 +71,6 @@
  */
 
 router.get('/pets', () => {
-
-});
-
-/*
- * @api [post] /pets
- *    description: "Creates a new pet in the store. Duplicates are allowed"
- *    operationId: "addPet"
- *    requestBody:
- *      description: "Pet to add to the store"
- *      required: true
- *      content:
- *        application/json:
- *          schema:
- *            $ref: "#/components/schemas/Pet"
- *    responses:
- *      "200":
- *        description: "pet response"
- *        content:
- *          application/json:
- *            schema:
- *              type: "array"
- *              items:
- *                $ref: "#/components/schemas/Pet"
- *      default:
- *        description: "unexpected error"
- *        content:
- *          application/json:
- *            schema:
- *              $ref: "#/components/schemas/ErrorModel"
- */
-
-router.post('/pets', () => {
 
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "swagger-inline",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "swagger-inline",
-      "version": "4.2.1",
+      "version": "4.2.2",
       "license": "ISC",
       "dependencies": {
         "commander": "^6.0.0",
@@ -2845,9 +2845,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001228",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
-      "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==",
+      "version": "1.0.30001277",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001277.tgz",
+      "integrity": "sha512-J2WtYj2Pl6LBEG214XmbGw1gzZEsYuinQFPqYtpZDB3/vm49qNlrcbJrTMkHKmdRDdmXYwkG0tgOBJsuI+J12Q==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -12885,9 +12885,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001228",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
-      "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==",
+      "version": "1.0.30001277",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001277.tgz",
+      "integrity": "sha512-J2WtYj2Pl6LBEG214XmbGw1gzZEsYuinQFPqYtpZDB3/vm49qNlrcbJrTMkHKmdRDdmXYwkG0tgOBJsuI+J12Q==",
       "dev": true
     },
     "chalk": {


### PR DESCRIPTION
## 🧰 What's being changed?

A common problem we've had with large codebases is that we can't guarantee that exported definitions are always exported with the same ordering. This often results in us making in non-API changes to a codebase that happen to also force a resorting of operations within the exported API definition for who knows why.

To combat that I'm introducing a force of alphabetical sorting on paths, path operations, and component schemas.

## 🧬 Testing

There aren't any snapshot updates here because i changed the `__tests__/__fixtures__/project-openapi/api.js` fixture to have non-alpha sorted content -- ensuring that these changes work.