### PR TITLE
Adding support for tabs along with spaces for inline comments

### DIFF
--- a/src/extractor.js
+++ b/src/extractor.js
@@ -11,7 +11,7 @@ function pushLine(array, line) {
 
 function loadYamlWithPrettyErrors(prettyObject, yamlLines) {
   try {
-    return jsYaml.load(yamlLines.join('\n'));
+    return jsYaml.load(yamlLines.join('\n'.replace('\t','    ')));
   } catch (e) {
     e.message = `YAML Exception in '${prettyObject}':\n${e.message}`;
     throw e;


### PR DESCRIPTION
This is an initial enhancement for the this [issue](https://github.com/readmeio/swagger-inline/issues/251).

This enhancement
- replaces `\t` characters with four spaces prior to loading the yaml the js-yaml library.

# Testing
Create a file with an inline `@oas` comment and use tabs instead of spaces when specifying the underlying yaml and run a swagger-inline command on that file. 