### PR TITLE
feat(index): add ability to specify `title` and `version` from CLI.

### DIFF
--- a/__tests__/cli.test.js
+++ b/__tests__/cli.test.js
@@ -54,4 +54,16 @@ describe('CLI', () => {
       expect(Object.keys(stdout.paths)).toHaveLength(2);
     });
   });
+
+  it("should update the tile and version when specified via the CLI", () => {
+    const workDir = path.resolve(__dirname, '../');
+    const cmd = `node bin/swagger-inline __tests__/__fixtures__/project-openapi --base __tests__/__fixtures__/project-openapi/openapiBase.json --title testTitle --apiVersion 2.0`;
+    return runCommand(cmd, workDir).then(result => {
+      expect(result.code).toBe(0);
+
+      const stdout = JSON.parse(result.stdout);
+      expect(stdout.info.title).toBe('testTitle');
+      expect(stdout.info.version).toBe('2.0');
+    });
+  });
 });

--- a/__tests__/cli.test.js
+++ b/__tests__/cli.test.js
@@ -55,7 +55,7 @@ describe('CLI', () => {
     });
   });
 
-  it("should update the tile and version when specified via the CLI", () => {
+  it("should update the title and version when specified via the CLI", () => {
     const workDir = path.resolve(__dirname, '../');
     const cmd = `node bin/swagger-inline __tests__/__fixtures__/project-openapi --base __tests__/__fixtures__/project-openapi/openapiBase.json --title testTitle --apiVersion 2.0`;
     return runCommand(cmd, workDir).then(result => {

--- a/__tests__/cli.test.js
+++ b/__tests__/cli.test.js
@@ -55,7 +55,7 @@ describe('CLI', () => {
     });
   });
 
-  it("should update the title and version when specified via the CLI", () => {
+  it('should update the title and version when specified via the CLI', () => {
     const workDir = path.resolve(__dirname, '../');
     const cmd = `node bin/swagger-inline __tests__/__fixtures__/project-openapi --base __tests__/__fixtures__/project-openapi/openapiBase.json --title testTitle --apiVersion 2.0`;
     return runCommand(cmd, workDir).then(result => {

--- a/src/cli.js
+++ b/src/cli.js
@@ -15,7 +15,7 @@ module.exports = function (args) {
       'Custom comment pattern supported by the multilang-extract-comments library in the form of a JSON file'
     ).option(
       '-t, --title [title]',
-      'Value to update the title attribute with in the base OpenAPI or Swagger definition'
+      'Value to update the `info.title` attribute with in the base OpenAPI or Swagger definition'
     ).option(
       '-v, --apiVersion [version]',
       'Value to update the version attribute with in the base OpenAPI or Swagger definition'

--- a/src/cli.js
+++ b/src/cli.js
@@ -18,7 +18,7 @@ module.exports = function (args) {
       'Value to update the `info.title` attribute with in the base OpenAPI or Swagger definition'
     ).option(
       '-v, --apiVersion [version]',
-      'Value to update the version attribute with in the base OpenAPI or Swagger definition'
+      'Value to update the `info.version` attribute with in the base OpenAPI or Swagger definition'
     );
 
   program.on('--help', () => {

--- a/src/cli.js
+++ b/src/cli.js
@@ -13,10 +13,12 @@ module.exports = function (args) {
     .option(
       '-p, --pattern [pattern]',
       'Custom comment pattern supported by the multilang-extract-comments library in the form of a JSON file'
-    ).option(
+    )
+    .option(
       '-t, --title [title]',
       'Value to update the `info.title` attribute with in the base OpenAPI or Swagger definition'
-    ).option(
+    )
+    .option(
       '-v, --apiVersion [version]',
       'Value to update the `info.version` attribute with in the base OpenAPI or Swagger definition'
     );
@@ -40,7 +42,7 @@ module.exports = function (args) {
     scope: program.scope,
     pattern: program.pattern,
     title: program.title,
-    apiVersion: program.apiVersion
+    apiVersion: program.apiVersion,
   };
 
   swaggerInline(program.args, providedOptions)

--- a/src/cli.js
+++ b/src/cli.js
@@ -13,6 +13,12 @@ module.exports = function (args) {
     .option(
       '-p, --pattern [pattern]',
       'Custom comment pattern supported by the multilang-extract-comments library in the form of a JSON file'
+    ).option(
+      '-t, --title [title]',
+      'Value to update the title attribute with in the base OpenAPI or Swagger definition'
+    ).option(
+      '-v, --apiVersion [version]',
+      'Value to update the version attribute with in the base OpenAPI or Swagger definition'
     );
 
   program.on('--help', () => {
@@ -33,6 +39,8 @@ module.exports = function (args) {
     format: program.format,
     scope: program.scope,
     pattern: program.pattern,
+    title: program.title,
+    apiVersion: program.apiVersion
   };
 
   swaggerInline(program.args, providedOptions)

--- a/src/index.js
+++ b/src/index.js
@@ -101,8 +101,8 @@ function swaggerInline(globPatterns, providedOptions) {
       }
 
       log(`${files.length} files matched...`);
-      
-      baseObj.info = updateTitleAndVersion(baseObj, options);
+
+      baseObj.info = updateTitleAndVersion(baseObj, options); // eslint-disable-line no-param-reassign
 
       return Loader.loadPattern(options.getPattern()).then(pattern => {
         if (pattern) {

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,6 @@ const Loader = require('./loader');
 const Extractor = require('./extractor');
 const Options = require('./options');
 
-
 function outputResult(object, options) {
   return new Promise(resolve => {
     const result = options.isJSON() ? JSON.stringify(object, null, 2) : jsYaml.dump(object);

--- a/src/index.js
+++ b/src/index.js
@@ -69,15 +69,14 @@ function mergeSchemasWithBase(swaggerBase = {}, schemas = []) {
 }
 
 function updateTitleAndVersion(baseObj, options) {
-  let info = baseObj.info ? baseObj.info : {};
+  const info = baseObj.info ? baseObj.info : {};
   if (options.getTitle()) {
     info.title = options.getTitle();
   }
   if (options.getApiVersion()) {
     info.version = options.getApiVersion();
   }
-  baseObj.info = info;
-  return baseObj;
+  return info;
 }
 
 function swaggerInline(globPatterns, providedOptions) {
@@ -96,14 +95,14 @@ function swaggerInline(globPatterns, providedOptions) {
   return Loader.resolvePaths(globPatterns, options).then(files => {
     return Loader.loadBase(base, options).then(baseObj => {
       const specVersion = parseInt(baseObj.swagger || baseObj.openapi, 10);
-      
+
       if (Object.keys(baseObj).length === 0) {
         throw new Error(`The base specification either wasn't found, or it is not a Swagger or OpenAPI definition.`);
       }
 
       log(`${files.length} files matched...`);
-
-      updateTitleAndVersion(baseObj, options);
+      
+      baseObj.info = updateTitleAndVersion(baseObj, options);
 
       return Loader.loadPattern(options.getPattern()).then(pattern => {
         if (pattern) {

--- a/src/index.js
+++ b/src/index.js
@@ -105,7 +105,6 @@ function swaggerInline(globPatterns, providedOptions) {
 
       updateTitleAndVersion(baseObj, options);
 
-
       return Loader.loadPattern(options.getPattern()).then(pattern => {
         if (pattern) {
           options.setPattern(pattern);

--- a/src/options.js
+++ b/src/options.js
@@ -53,6 +53,15 @@ class Options {
     this.options.pattern = pattern;
     return this.options;
   }
+
+  getTitle() {
+    return this.options.title;
+  }
+
+  getApiVersion() {
+    return this.options.apiVersion;
+  }
+
 }
 
 Options.DEFAULTS = {
@@ -61,6 +70,8 @@ Options.DEFAULTS = {
   ignore: ['node_modules/**/*', 'bower_modules/**/*'],
   ignoreErrors: false,
   pattern: null,
+  title: null,
+  apiVersion: null
 };
 
 module.exports = Options;

--- a/src/options.js
+++ b/src/options.js
@@ -61,7 +61,6 @@ class Options {
   getApiVersion() {
     return this.options.apiVersion;
   }
-
 }
 
 Options.DEFAULTS = {
@@ -71,7 +70,7 @@ Options.DEFAULTS = {
   ignoreErrors: false,
   pattern: null,
   title: null,
-  apiVersion: null
+  apiVersion: null,
 };
 
 module.exports = Options;


### PR DESCRIPTION
## 🧰 What's being changed?

This enhancement:

- Added two option CLI arguments `title` and `apiVersion`
- Added the `updateTitleAndVersion()` method to index.js to update the `title` and `version` attributes of a swagger or OAS files `info` object if specified with the added CLI arguments
- Calls the `updateTitleAndVersion()` after the base file is confirmed to be loaded

## 🧬 Testing

Run the following command `node bin/swagger-inline __tests__/__fixtures__/project-openapi --base __tests__/__fixtures__/project-openapi/openapiBase.json --title testTitle --apiVersion 2.0` and confirm the `title` and `version` attributes of the `info` object in the outputted swagger/oas.json file are `testTitle` and `2.0` respectively based on the CLI input.