### PR TITLE
fix: more error handling for files that will never contain docblocks

### DIFF
--- a/__tests__/__fixtures__/project-openapi/README.markdown
+++ b/__tests__/__fixtures__/project-openapi/README.markdown
@@ -1,0 +1,3 @@
+This is a test README.
+
+It should not be picked up by `swagger-inline` and throw errors because it doesn't have any docblocks.

--- a/src/index.js
+++ b/src/index.js
@@ -134,7 +134,7 @@ function swaggerInline(globPatterns, providedOptions) {
                   });
                 } catch (err) {
                   // If the file that we failed to parse is a text file, let's just ignore it.
-                  if (['.json', '.md', '.txt'].includes(path.extname(fileInfo.fileName))) {
+                  if (['.json', '.md', '.markdown', '.txt'].includes(path.extname(fileInfo.fileName))) {
                     return Promise.resolve();
                   } else if (/Cannot find language definition/.test(err.message)) {
                     return Promise.resolve();


### PR DESCRIPTION
## 🧰 Changes

Follow on from this PR: https://github.com/readmeio/swagger-inline/pull/196 which added support for ignoring `multiline-extract-comments` from markdown files. We only accounted for `.md` extensions and not `.markdown`, which is also valid.

This will fix an error upstream in the readme-micro action which uses swagger-inline to try and extract openapi operations from code.

## 🧬 QA & Testing

Do the tests pass? 
