### PR TITLE
chore: remove `promise.any` polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,7 @@
         "commander": "^6.0.0",
         "globby": "^11.0.1",
         "js-yaml": "^4.1.0",
-        "multilang-extract-comments": "^0.4.0",
-        "promise.any": "^2.0.2"
+        "multilang-extract-comments": "^0.4.0"
       },
       "bin": {
         "swagger-inline": "bin/swagger-inline"
@@ -5707,26 +5706,6 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/promise.any": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/promise.any/-/promise.any-2.0.6.tgz",
-      "integrity": "sha512-Ew/MrPtTjiHnnki0AA2hS2o65JaZ5n+5pp08JSyWWUdeOGF4F41P+Dn+rdqnaOV/FTxhR6eBDX412luwn3th9g==",
-      "dependencies": {
-        "array.prototype.map": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "es-aggregate-error": "^1.0.10",
-        "get-intrinsic": "^1.2.1",
-        "iterate-value": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/prop-types": {

--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
     "commander": "^6.0.0",
     "globby": "^11.0.1",
     "js-yaml": "^4.1.0",
-    "multilang-extract-comments": "^0.4.0",
-    "promise.any": "^2.0.2"
+    "multilang-extract-comments": "^0.4.0"
   },
   "devDependencies": {
     "@readme/eslint-config": "^14.8.1",

--- a/src/loader.js
+++ b/src/loader.js
@@ -5,8 +5,6 @@ const path = require('path');
 
 const globby = require('globby');
 const jsYaml = require('js-yaml');
-// eslint-disable-next-line unicorn/no-unnecessary-polyfills
-const any = require('promise.any');
 
 class Loader {
   static resolvePaths(filepaths, options) {
@@ -26,7 +24,7 @@ class Loader {
           });
         });
 
-        return any(promises).catch(Promise.reject);
+        return Promise.any(promises).catch(Promise.reject);
       })
       .catch(Promise.reject);
   }


### PR DESCRIPTION
Removes `promise.any` dependency

`Promise.any` is available natively since Node 15.0.0
